### PR TITLE
Add Kafka Messaging for Order Notifications

### DIFF
--- a/src/main/java/org/example/orderservice/config/KafkaConfig.java
+++ b/src/main/java/org/example/orderservice/config/KafkaConfig.java
@@ -1,0 +1,16 @@
+package org.example.orderservice.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfig {
+  @Bean
+  public NewTopic notificationTopic() {
+    return TopicBuilder
+            .name("notificationTopic")
+            .build();
+  }
+}

--- a/src/main/java/org/example/orderservice/service/OrderService.java
+++ b/src/main/java/org/example/orderservice/service/OrderService.java
@@ -1,12 +1,23 @@
 package org.example.orderservice.service;
 
 import org.example.orderservice.model.Order;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 public class OrderService {
+  private final KafkaTemplate<String, Object> kafkaTemplate;
+
+  @Autowired
+  public OrderService(KafkaTemplate<String, Object> kafkaTemplate) {
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
   public Order placeOrder(Order order) {
     order.setOrderId(generateOrderId());
+
+    kafkaTemplate.send("notificationTopic", order.getOrderId());
 
     return order;
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=order-service
+
+server.port=8080
+
+# Kafka Properties
+spring.kafka.producer.bootstrap-servers=localhost:9092
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
### Description:
This pull request introduces the integration of Apache Kafka messaging into the Order Service application.

### Changes:
- **Added KafkaConfig class:** Added a new configuration class `KafkaConfig` in the `config` package to create a Kafka topic named `notificationTopic`.
- **Modified OrderService:** Modified the `OrderService` class in the `service` package to send a Kafka message containing the order ID to the `notificationTopic` upon placing an order.
- **Updated application.properties:** Updated the `application.properties` file to configure Kafka producer properties such as bootstrap servers and serializers.

### Purpose:
The purpose of this pull request is to enable the Order Service to publish order notifications to the `notificationTopic` Kafka topic whenever a new order is placed. This allows other services or components interested in order events to consume these notifications from the Kafka topic for further processing, logging, or integration purposes.